### PR TITLE
graphql-codegenで作ったresolversの型定義が使いにくい

### DIFF
--- a/server/codegen.json
+++ b/server/codegen.json
@@ -13,6 +13,7 @@
     "./graphql.schema.json": { "plugins": ["introspection"] }
   },
   "config": {
-    "addUnderscoreToArgsType": true
+    "addUnderscoreToArgsType": true,
+    "useIndexSignature": true
   }
 }

--- a/server/memo.md
+++ b/server/memo.md
@@ -1,0 +1,38 @@
+import { ulid } from 'ulid';
+import {
+MutationResolvers,
+QueryResolvers,
+Resolvers,
+} from './gen/graphql-resolver-types';
+import { User } from './entity/User';
+
+const Query: QueryResolvers = {
+async user(\_parent, args, \_context, \_info) {
+const user = await User.findOne({ id: args.id });
+return user || null;
+},
+async users() {
+const users = await User.find();
+return users;
+},
+};
+
+const Mutation: MutationResolvers = {
+async addUser(\_parent, args, \_context, \_info) {
+const newUser = new User();
+newUser.id = ulid();
+newUser.name = args.name;
+await User.save(newUser);
+return newUser;
+},
+async deleteUser(\_parent, args, \_context, \_info) {
+const user = await User.findOne(args.id);
+await User.delete(args.id);
+return user;
+},
+};
+
+export const resolvers: Resolvers = {
+Query,
+Mutation,
+};

--- a/server/package.json
+++ b/server/package.json
@@ -39,6 +39,7 @@
     "apollo-server-express": "^2.9.6",
     "express": "^4.17.1",
     "graphql": "^14.5.8",
+    "graphql-tools": "^4.0.6",
     "isemail": "^3.2.0",
     "nodemon": "^1.19.3",
     "sequelize": "^5.19.5",

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -1,7 +1,5 @@
 import Express from 'express';
 import { ApolloServer } from 'apollo-server-express';
-import { IResolvers } from 'graphql-tools';
-
 // import { makeExecutableSchema, IResolvers } from 'graphql-tools';
 import { resolvers } from './resolvers';
 import { typeDefs } from './schema';
@@ -23,7 +21,7 @@ const dataSources = () => ({
 // こっから初期化
 const server = new ApolloServer({
   typeDefs,
-  resolvers: resolvers as IResolvers,
+  resolvers: resolvers as any,
   dataSources,
 });
 

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -1,5 +1,8 @@
 import Express from 'express';
 import { ApolloServer } from 'apollo-server-express';
+import { IResolvers } from 'graphql-tools';
+
+// import { makeExecutableSchema, IResolvers } from 'graphql-tools';
 import { resolvers } from './resolvers';
 import { typeDefs } from './schema';
 import UserAPI from './datasources/user';
@@ -12,8 +15,17 @@ const dataSources = () => ({
   courseAPI: new CourseAPI(store),
 });
 
+// const schema = makeExecutableSchema({
+//   typeDefs,
+//   resolvers: resolvers as IResolvers,
+// });
+
 // こっから初期化
-const server = new ApolloServer({ typeDefs, resolvers, dataSources });
+const server = new ApolloServer({
+  typeDefs,
+  resolvers: resolvers as IResolvers,
+  dataSources,
+});
 
 const app = Express();
 

--- a/server/src/resolvers.ts
+++ b/server/src/resolvers.ts
@@ -1,14 +1,17 @@
-import { QueryResolvers } from './types/generated';
+import { QueryResolvers, User, Course } from './types/generated';
 
 export const resolvers: QueryResolvers = {
-  async findUser(_root, args, context) {
-    const { dataSources } = await context;
-
-    return dataSources.userAPI.findUser();
-  },
   async test(_root, args, context) {
     const { dataSources } = await context;
 
-    return dataSources.courseAPI.test();
+    const result: Course = dataSources.courseAPI.test();
+
+    return result;
+  },
+  async findUser(_root, args, context) {
+    const { dataSources } = await context;
+    const result: User = dataSources.userAPI.findUser();
+
+    return result;
   },
 };

--- a/server/src/resolvers.ts
+++ b/server/src/resolvers.ts
@@ -1,6 +1,6 @@
-import { QueryResolvers, User, Course } from './types/generated';
+import { QueryResolvers, Resolvers, User, Course } from './types/generated';
 
-export const resolvers: QueryResolvers = {
+const Query: QueryResolvers = {
   async test(_root, args, context) {
     const { dataSources } = await context;
 
@@ -14,4 +14,8 @@ export const resolvers: QueryResolvers = {
 
     return result;
   },
+};
+
+export const resolvers: Resolvers = {
+  Query,
 };


### PR DESCRIPTION
graphql-codegenのoptionを追加したらワンチャンどうにかなりそう。